### PR TITLE
Remove unnecessary abstraction on use cases

### DIFF
--- a/lib_use_case/lib/src/di/di.config.dart
+++ b/lib_use_case/lib/src/di/di.config.dart
@@ -26,14 +26,14 @@ extension GetItInjectableX on _i1.GetIt {
       environment,
       environmentFilter,
     );
-    gh.factory<_i3.FetchBooksUseCase>(() => _i3.FetchBooksUseCaseImpl(
+    gh.factory<_i3.FetchBooksUseCase>(() => _i3.FetchBooksUseCase(
           gh<_i4.BookRepository>(),
           gh<_i4.SyncLogRepository>(),
         ));
     gh.factory<_i5.GetLocalBooksUseCase>(
-        () => _i5.GetLocalBooksUseCaseImpl(gh<_i4.BookRepository>()));
+        () => _i5.GetLocalBooksUseCase(gh<_i4.BookRepository>()));
     gh.factory<_i6.LoadHighlightFeedsUseCase>(
-        () => _i6.LoadHighlightFeedsUseCaseImpl(gh<_i4.HighlightRepository>()));
+        () => _i6.LoadHighlightFeedsUseCase(gh<_i4.HighlightRepository>()));
     return this;
   }
 }

--- a/lib_use_case/lib/src/use_case/fetch_books_use_case.dart
+++ b/lib_use_case/lib/src/use_case/fetch_books_use_case.dart
@@ -2,18 +2,13 @@ import 'package:core_data/core_data.dart';
 import 'package:core_model/core_model.dart';
 import 'package:injectable/injectable.dart';
 
-abstract class FetchBooksUseCase {
-  Future<List<Book>> invoke();
-}
-
-@Injectable(as: FetchBooksUseCase)
-class FetchBooksUseCaseImpl extends FetchBooksUseCase {
+@Injectable()
+class FetchBooksUseCase {
   final BookRepository _bookRepository;
   final SyncLogRepository _syncLogRepository;
 
-  FetchBooksUseCaseImpl(this._bookRepository, this._syncLogRepository);
+  FetchBooksUseCase(this._bookRepository, this._syncLogRepository);
 
-  @override
   Future<List<Book>> invoke() async {
     final lastSync = await _syncLogRepository.loadLastAllBooksSync();
     final bookEntities = await _bookRepository.fetchBooks(lastSync);

--- a/lib_use_case/lib/src/use_case/get_local_books_use_case.dart
+++ b/lib_use_case/lib/src/use_case/get_local_books_use_case.dart
@@ -2,23 +2,18 @@ import 'package:core_data/core_data.dart';
 import 'package:core_model/core_model.dart';
 import 'package:injectable/injectable.dart';
 
-abstract class GetLocalBooksUseCase {
-  Future<List<Book>> invoke();
-}
-
-@Injectable(as: GetLocalBooksUseCase)
-class GetLocalBooksUseCaseImpl extends GetLocalBooksUseCase {
+@Injectable()
+class GetLocalBooksUseCase {
   final BookRepository _bookRepository;
 
-  GetLocalBooksUseCaseImpl(this._bookRepository);
+  GetLocalBooksUseCase(this._bookRepository);
 
-  @override
   Future<List<Book>> invoke() async {
     final entities = await _bookRepository.loadBooks();
     entities.sort(
-      (a, b) {
+          (a, b) {
         final asc =
-            DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
+        DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
         return -asc;
       },
     );

--- a/lib_use_case/lib/src/use_case/get_local_books_use_case.dart
+++ b/lib_use_case/lib/src/use_case/get_local_books_use_case.dart
@@ -11,9 +11,9 @@ class GetLocalBooksUseCase {
   Future<List<Book>> invoke() async {
     final entities = await _bookRepository.loadBooks();
     entities.sort(
-          (a, b) {
+      (a, b) {
         final asc =
-        DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
+            DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
         return -asc;
       },
     );

--- a/lib_use_case/lib/src/use_case/load_highlight_feeds/load_highlight_feeds_use_case.dart
+++ b/lib_use_case/lib/src/use_case/load_highlight_feeds/load_highlight_feeds_use_case.dart
@@ -20,9 +20,9 @@ class LoadHighlightFeedsUseCase {
     );
 
     entities.sort(
-          (a, b) {
+      (a, b) {
         final asc =
-        DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
+            DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
         return -asc;
       },
     );
@@ -30,12 +30,12 @@ class LoadHighlightFeedsUseCase {
     return entities
         .map(
           (e) => HighlightFeed(
-        id: e.id,
-        bookId: e.bookId,
-        author: e.author,
-        text: e.text,
-      ),
-    )
+            id: e.id,
+            bookId: e.bookId,
+            author: e.author,
+            text: e.text,
+          ),
+        )
         .toList();
   }
 }

--- a/lib_use_case/lib/src/use_case/load_highlight_feeds/load_highlight_feeds_use_case.dart
+++ b/lib_use_case/lib/src/use_case/load_highlight_feeds/load_highlight_feeds_use_case.dart
@@ -3,21 +3,12 @@ import 'package:injectable/injectable.dart';
 import 'package:lib_use_case/src/use_case/load_highlight_feeds/highlight_feed.dart';
 import 'package:lib_use_case/src/use_case/load_highlight_feeds/highlight_feed_filter.dart';
 
-abstract class LoadHighlightFeedsUseCase {
-  Future<List<HighlightFeed>> invoke(
-    int pageKey,
-    int pageSize, {
-    HighlightFeedFilter? filter,
-  });
-}
-
-@Injectable(as: LoadHighlightFeedsUseCase)
-class LoadHighlightFeedsUseCaseImpl extends LoadHighlightFeedsUseCase {
+@Injectable()
+class LoadHighlightFeedsUseCase {
   final HighlightRepository _highlightRepository;
 
-  LoadHighlightFeedsUseCaseImpl(this._highlightRepository);
+  LoadHighlightFeedsUseCase(this._highlightRepository);
 
-  @override
   Future<List<HighlightFeed>> invoke(int pageKey, int pageSize,
       {HighlightFeedFilter? filter}) async {
     final entities = await _highlightRepository.searchHighlights(
@@ -29,9 +20,9 @@ class LoadHighlightFeedsUseCaseImpl extends LoadHighlightFeedsUseCase {
     );
 
     entities.sort(
-      (a, b) {
+          (a, b) {
         final asc =
-            DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
+        DateTime.parse(a.updated).compareTo(DateTime.parse(b.updated));
         return -asc;
       },
     );
@@ -39,12 +30,12 @@ class LoadHighlightFeedsUseCaseImpl extends LoadHighlightFeedsUseCase {
     return entities
         .map(
           (e) => HighlightFeed(
-            id: e.id,
-            bookId: e.bookId,
-            author: e.author,
-            text: e.text,
-          ),
-        )
+        id: e.id,
+        bookId: e.bookId,
+        author: e.author,
+        text: e.text,
+      ),
+    )
         .toList();
   }
 }


### PR DESCRIPTION
Use cases are single responsibility, and in this app there's no multiple implementations of a use case. Hence, having an abstract interface for each use case is redundant and boilerplate.

Inspired by the practical implementation from the [nowinandroid](https://github.com/android/nowinandroid/tree/main/core/domain/src/main/java/com/google/samples/apps/nowinandroid/core/domain) project.